### PR TITLE
chore: links to github repositories give an error

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@
 - The `NegRiskAdapter` provides an adapter interface for the Gnosis Conditional Tokens Framework (CTF) which allows users to _convert_ collections of NO tokens in mutually-exclusive binary markets into a corresponding position of YES tokens and collateral. [Notes](./NegRiskAdapter.md).
 - The `NegRiskOperator` is designed to allow admin accounts to prepare questions and markets, as well as to integrate with resolution sources. [Notes](./NegRiskOperator.md).
 - The `Vault` is a permmissioned vault for holding USDC and Yes tokens which are collected as fees from users who choose to convert NO positions, given a positive fee rate.
-- The `NegRiskCtfExchange` is a lightweight fork of Polymarket's exchange contract: (https://github.com/Polymarket/ctf-exchange)[https://github.com/Polymarket/ctf-exchange]. It is designed to be enable trading with Polymarket's CLOB in NegRisk markets.
-- The `NegRiskFeeModule` is a lightweight fork of Polymarket's fee module: (https://github.com/Polymarket/exchange-fee-module)[https://github.com/Polymarket/exchange-fee-module]. It is designed to be used with the NegRiskCtfExchange.
+- The `NegRiskCtfExchange` is a lightweight fork of Polymarket's exchange contract: [https://github.com/Polymarket/ctf-exchange](https://github.com/Polymarket/ctf-exchange). It is designed to be enable trading with Polymarket's CLOB in NegRisk markets.
+- The `NegRiskFeeModule` is a lightweight fork of Polymarket's fee module: [https://github.com/Polymarket/exchange-fee-module](https://github.com/Polymarket/exchange-fee-module). It is designed to be used with the NegRiskCtfExchange.
 - The `WrappedCollateral` contract is an ERC20 which wraps collateral (namely USDC) and which is used to collateralize all Neg Risk markets and positions.
 
 ## Modules


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes the markdown links to Polymarket repositories in `docs/index.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0b355057fb55e1c6b57c607445a2f145fc3bd2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->